### PR TITLE
Prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.0.0 – 2024-09-11
+
+### Changed
+
+- Remove default API key
+- Bump max NC version to 31
+- Drop NC 26 support
+- Ask password confirmation when setting sensitive setting values
+- Update NPM pkgs
+
 ## 1.0.4 – 2024-04-04
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>The Movie Database integration</name>
     <summary>Integration of The Movie Database</summary>
     <description><![CDATA[TMDB integration provides a smart picker provider to search for movies, series or actors and link previews for them.]]></description>
-    <version>1.0.4</version>
+    <version>2.0.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Tmdb</namespace>


### PR DESCRIPTION
### Changed

- Remove default API key
- Bump max NC version to 31
- Drop NC 26 support
- Ask password confirmation when setting sensitive setting values
- Update NPM pkgs