### PR TITLE
Prepare release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.2.0 – 2024-08-29
+
+### Added
+- search providers marked as external sources 
+
+### Changed
+- npm packages updated 
+- max NC version bumped to 32
+- CSP Nonce updated
+- change icons to outlined versions
+
 ## 2.1.0 – 2024-10-23
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>The Movie Database integration</name>
     <summary>Integration of The Movie Database</summary>
     <description><![CDATA[TMDB integration provides a smart picker provider to search for movies, series or actors and link previews for them.]]></description>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Tmdb</namespace>


### PR DESCRIPTION
### Added
- search providers marked as external sources 

### Changed
- npm packages updated 
- max NC version bumped to 32
- CSP Nonce updated
- change icons to outlined versions