### PR TITLE
prepare 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## 2.2.0 – 2024-08-29
+## 2.2.1 – 2025-09-01
+
+### Changed
+
+- Lower max NC version to 31
+- Do not use IExternalProvider anymore
+
+## 2.2.0 – 2025-08-29
 
 ### Added
 - search providers marked as external sources 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>The Movie Database integration</name>
     <summary>Integration of The Movie Database</summary>
     <description><![CDATA[TMDB integration provides a smart picker provider to search for movies, series or actors and link previews for them.]]></description>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Tmdb</namespace>
@@ -18,7 +18,7 @@
     <screenshot>https://github.com/julien-nc/integration_tmdb/raw/main/img/screenshot2.jpg</screenshot>
     <screenshot>https://github.com/julien-nc/integration_tmdb/raw/main/img/screenshot3.jpg</screenshot>
     <dependencies>
-        <nextcloud min-version="27" max-version="32"/>
+        <nextcloud min-version="27" max-version="31"/>
     </dependencies>
     <settings>
         <admin>OCA\Tmdb\Settings\Admin</admin>


### PR DESCRIPTION
### Changed

- Lower max NC version to 31
- Do not use IExternalProvider anymore