### PR TITLE
chore: prepare 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 3.1.0 – 2026-04-13
+
+### Changed
+
+- Bump max NC version to 34
+- Modernize settings design
+- Lazy load app config values
+- Update npm packages
+- Update composer packages
+
 ## 3.0.1 – 2025-12-04
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>The Movie Database integration</name>
     <summary>Integration of The Movie Database</summary>
     <description><![CDATA[TMDB integration provides a smart picker provider to search for movies, series or actors and link previews for them.]]></description>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <licence>AGPL-3.0-or-later</licence>
     <author>Julien Veyssier</author>
     <namespace>Tmdb</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
     <screenshot>https://github.com/julien-nc/integration_tmdb/raw/main/img/screenshot2.jpg</screenshot>
     <screenshot>https://github.com/julien-nc/integration_tmdb/raw/main/img/screenshot3.jpg</screenshot>
     <dependencies>
-        <nextcloud min-version="32" max-version="33"/>
+        <nextcloud min-version="32" max-version="34"/>
     </dependencies>
     <settings>
         <admin>OCA\Tmdb\Settings\Admin</admin>


### PR DESCRIPTION
### Changed

- Bump max NC version to 34
- Modernize settings design
- Lazy load app config values
- Update npm packages
- Update composer packages