### PR TITLE
chore(workflows): update MySQL test matrix

### DIFF
--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -70,16 +70,16 @@ jobs:
     strategy:
       #matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
       matrix:
-        php-versions: ['8.4']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
         mysql-versions: ['8.4']
-        server-versions: ['stable32', 'master']
-        include:
+        server-versions: ['stable32', 'stable33', 'stable34', 'master']
+        exclude:
           - php-versions: 8.2
             mysql-versions: 8.4
             server-versions: master
-          - php-versions: 8.3
+          - php-versions: 8.5
             mysql-versions: 8.4
-            server-versions: master
+            server-versions: stable32
 
 
     name: MySQL ${{ matrix.mysql-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}


### PR DESCRIPTION
Adds Nextcloud version branches `stable33` and `stable34` to the matrix, and updates the PHP versions tested for each Nextcloud server version.